### PR TITLE
irony

### DIFF
--- a/xv.c
+++ b/xv.c
@@ -2170,8 +2170,8 @@ static int openPic(filenum)
   /* ABSOLUTELY no failures from here on out... */
 
 
-  if (strlen(pinfo.pagebname)) {
-    strcpy(pageBaseName, pinfo.pagebname);
+  if (strnlen(pinfo.pagebname, 1)) {
+    strncpy(pageBaseName, pinfo.pagebname, PAGEBNAMELEN);
     numPages = pinfo.numpages;
     curPage = 0;
   }

--- a/xv.h
+++ b/xv.h
@@ -889,7 +889,8 @@ typedef struct { byte *pic;                  /* image data */
 		 char *comment;              /* comment text */
 
 		 int   numpages;             /* # of page files, if >1 */
-		 char  pagebname[64];        /* basename of page files */
+#define PAGEBNAMELEN 64
+		 char  pagebname[PAGEBNAMELEN]; /* basename of page files */
 	       } PICINFO;
 
 #define MAX_GHANDS 16   /* maximum # of GRAF handles */


### PR DESCRIPTION
  /* ABSOLUTELY no failures from here on out... */

right in xv.c

Philadelphia is the most lead poisoned city in the USA.

I should go back and start over with this crossword puzzle or suduko game or whatever.
I'd #define every char array len and then I could use the defines to strnlen() etc.

It all started when I tried to use eog over an X11 connection and it didn't open a window.
First Google Chrome stopped working over X11 connections then Firefox and now eog.
I just wanted my xv back like the good old days before people decided to take a full networked window system and destroy the network part.
Then I discovered the awful truth about xv.
What I really want is the 90s back.